### PR TITLE
bump to java 16 so we can build 1.17

### DIFF
--- a/hub/Dockerfile
+++ b/hub/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-alpine
+FROM openjdk:16-alpine
 COPY build.sh /build/build.sh
 WORKDIR /build
 

--- a/hub/build.sh
+++ b/hub/build.sh
@@ -6,4 +6,4 @@ rm -rf BuildTools.jar
 wget https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar -O BuildTools.jar
 
 export MAVEN_OPTS="-Xmx2G"
-java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xmx2G -jar BuildTools.jar "$@"
+java -XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport -Xmx2G -jar BuildTools.jar "$@"


### PR DESCRIPTION
remove UseCGroupMemoryLimitForHeap and replace with UseContainerSupport(see https://www.atamanroman.dev/articles/jvm-memory-settings-container-environment/)

This addresses issue #1 