### PR TITLE
ic of makefile that can be used to quickly build a latest and git commit id tagged image.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ build: getcommitid
 	docker tag $(REGISTRY_NAME)$(REPOSITORY_NAME)$(IMAGE_NAME)$(TAG) $(REGISTRY_NAME)$(REPOSITORY_NAME)$(IMAGE_NAME):$(COMMITID)
 
 run:
-	docker run -d $(RUN_PORTS) $(REGISTRY_NAME)$(REPOSITORY_NAME)$(IMAGE_NAME)$(TAG)
+	docker run --name spigotmc-build $(REGISTRY_NAME)$(REPOSITORY_NAME)$(IMAGE_NAME)$(TAG)
 
 size:
 	docker inspect -f "{{ .Size }}" $(REGISTRY_NAME)$(REPOSITORY_NAME)$(IMAGE_NAME)$(TAG)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+REGISTRY_NAME := 
+REPOSITORY_NAME := sindastra/
+IMAGE_NAME := spigotmc-build
+TAG := :latest
+
+.PHONY: getcommitid
+
+
+
+all: build
+
+getcommitid: 
+	$(eval COMMITID = $(shell git log -1 --pretty=format:"%H"))
+
+build: getcommitid
+	docker build -t $(REGISTRY_NAME)$(REPOSITORY_NAME)$(IMAGE_NAME)$(TAG) hub/.
+	docker tag $(REGISTRY_NAME)$(REPOSITORY_NAME)$(IMAGE_NAME)$(TAG) $(REGISTRY_NAME)$(REPOSITORY_NAME)$(IMAGE_NAME):$(COMMITID)
+
+run:
+	docker run -d $(RUN_PORTS) $(REGISTRY_NAME)$(REPOSITORY_NAME)$(IMAGE_NAME)$(TAG)
+
+size:
+	docker inspect -f "{{ .Size }}" $(REGISTRY_NAME)$(REPOSITORY_NAME)$(IMAGE_NAME)$(TAG)
+	docker history $(REGISTRY_NAME)$(REPOSITORY_NAME)$(IMAGE_NAME)$(TAG)
+
+publish:
+	docker login; docker push $(REGISTRY_NAME)$(REPOSITORY_NAME)$(IMAGE_NAME)$(TAG); docker logout


### PR DESCRIPTION
Also has targets to get the size of the built image and quickly publish.

I enjoy using a somewhat standard Makefile for building my docker images during development. I used this to build my own custom tagged image while working on pr #2 and wanted to share in case you would find it useful. 